### PR TITLE
Fix some compiler warnings

### DIFF
--- a/oshw-sdl/sdlout.c
+++ b/oshw-sdl/sdlout.c
@@ -267,7 +267,7 @@ static int createdisplay(void)
     }
     if (sdlg.screen->w != screenw || sdlg.screen->h != screenh)
 	warn("requested a %dx%d display, got %dx%d instead",
-	     sdlg.screen->w, sdlg.screen->h);
+	     screenw, screenh, sdlg.screen->w, sdlg.screen->h);
     return TRUE;
 }
 

--- a/play.c
+++ b/play.c
@@ -186,8 +186,10 @@ void setgameplaymode(int mode)
 	settimer(-1);
 	break;
       case SuspendPlayShuttered:
-	if (state.ruleset == Ruleset_MS)
+	if (state.ruleset == Ruleset_MS) {
 	    state.statusflags |= SF_SHUTTERED;
+	}
+	/* fallthrough */
       case SuspendPlay:
 	setkeyboardrepeat(TRUE);
 	settimer(0);

--- a/series.c
+++ b/series.c
@@ -193,7 +193,7 @@ static int readleveldata(fileinfo *file, gamesetup *game)
     size = data[0] | (data[1] << 8);
     data += 2;
     if (data + size != dataend)
-	warn("level %d: inconsistent size data (%d vs %d)",
+	warn("level %d: inconsistent size data (%ld vs %d)",
 	     game->number, dataend - data, size);
 
     while (data + 2 < dataend) {

--- a/series.c
+++ b/series.c
@@ -193,7 +193,7 @@ static int readleveldata(fileinfo *file, gamesetup *game)
     size = data[0] | (data[1] << 8);
     data += 2;
     if (data + size != dataend)
-	warn("level %d: inconsistent size data (%ld vs %d)",
+	warn("level %d: inconsistent size data (%td vs %d)",
 	     game->number, dataend - data, size);
 
     while (data + 2 < dataend) {


### PR DESCRIPTION
Details on the commits.

I found the format string problems by annotating `warn`, `errmsg`, and `die` with GCC's `format` attribute. https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-format-function-attribute

```c
extern void _warn(char const *fmt, ...)  __attribute__((format (printf, 1, 2)));
extern void _errmsg(char const *prefix, char const *fmt, ...)  __attribute__((format (printf, 2, 3)));;
extern void _die(char const *fmt, ...)  __attribute__((format (printf, 1, 2)));;
```

I'm not sure how you feel about adding GCC-specific attributes to the code so i left that change out of the PR.